### PR TITLE
Replace deprecated constant with a newer one

### DIFF
--- a/custom_components/huawei_hg659/device_tracker.py
+++ b/custom_components/huawei_hg659/device_tracker.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 
 from homeassistant.components.device_tracker import (
     DeviceScanner,
-    SOURCE_TYPE_ROUTER,
+    SourceType,
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
@@ -58,7 +58,7 @@ class HuaweiH659DeviceScanner(DeviceScanner):
         return None
     def source_type(self):
         """Return the source type, eg gps or router, of the device."""
-        return SOURCE_TYPE_ROUTER
+        return SourceType.ROUTER
     def _update_info(self):
         """Ensure the information from the router is up to date.
 


### PR DESCRIPTION
A deprecated message has appeared in the logs with regards to the use of a constant. I replaced it with the newer constant, like the message indicates we should.